### PR TITLE
I modified js/index.js slightly to deal with errors in Lambda Console Test

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -17,7 +17,8 @@ exports.handler = function(event, context, callback){
         audioEventHandlers
     );
 
-    if (event.context.System.device.supportedInterfaces.AudioPlayer === undefined) {
+    var audioPlayerInterface = ((((event.context || {}).System || {}).device || {}).supportedInterfaces || {}).AudioPlayer;
+    if (audioPlayerInterface === undefined) {
         alexa.emit(':tell', 'Sorry, this skill is not supported on this device');
     }
     else {


### PR DESCRIPTION
The issue I found was that the code in `js/index.js` throws an error when used in the **Lambda Console** for **Test**. This line of code causes problems:

``` javascript
if (event.context.System.device.supportedInterfaces.AudioPlayer === undefined)
```

The Lambda Console does not have an event.context.System object, so we are access a property of an undefined object. My fix was simply this:

``` javascript
var audioPlayerInterface = ((((event.context || {}).System || {}).device || {}).supportedInterfaces || {}).AudioPlayer;
if (audioPlayerInterface === undefined) {
```

This works fine now in the **Lambda Console** when performing a test.
