### PR TITLE
Enable auto-play

### DIFF
--- a/multiple-streams/lambda/src/index.js
+++ b/multiple-streams/lambda/src/index.js
@@ -473,6 +473,7 @@ const controller = {
     const playBehavior = 'REPLACE_ALL';
     const podcast = constants.audioData[playOrder[index]];
     const token = playOrder[index];
+    playbackInfo.nextStreamEnqueued = false;
 
     responseBuilder
       .speak(`This is ${podcast.title}`)


### PR DESCRIPTION
Enable the auto-playing for the audio-player after resuming the skill with the previous session. 
Here is the logged issue: https://github.com/alexa/skill-sample-nodejs-audio-player/issues/104

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
