### PR TITLE
Changing License Location

### DIFF
--- a/single-stream/lambda/package.json
+++ b/single-stream/lambda/package.json
@@ -14,7 +14,7 @@
     "audio player"
   ],
   "author": "Sébastien Stormacq",
-  "license": "See license in ../../LICENSE.txt",
+  "license": "../../LICENSE.txt",
   "dependencies": {
     "ask-sdk": "^2.0.10"
   },


### PR DESCRIPTION
When downloading Mocha and Chai testing packages, an error message shows up that looks like:
"npm WARN skill_sample_nodejs_sdkv2_single_stream@2.0.0 license should be a valid SPDX license expression"
Because the license storage location is currently,   "license": "See license in ../../LICENSE.txt","
Changing to   "license": "../../LICENSE.txt"," to correct error message.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
