### PR TITLE
Use standard name for handlerInput

### DIFF
--- a/multiple-streams/lambda/src/index.js
+++ b/multiple-streams/lambda/src/index.js
@@ -301,8 +301,8 @@ const YesHandler = {
 
     return !playbackInfo.inPlaybackSession && request.type === 'IntentRequest' && request.intent.name === 'AMAZON.YesIntent';
   },
-  handle(handleInput) {
-    return controller.play(handleInput);
+  handle(handlerInput) {
+    return controller.play(handlerInput);
   },
 };
 


### PR DESCRIPTION
*Description of changes: Changed parameter name handleInput to handlerInput to fill the standard naming convention.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
